### PR TITLE
feat: `connectUrl()` instance method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,12 @@ export type ClientOptions = {
   baseConnectURL?: string
 }
 
-export type LoadOptions = {
+export type ConnectOptions = {
   sessionId?: string
+  proxy?: boolean
+}
+
+export type LoadOptions = ConnectOptions & {
   textContent?: boolean
 }
 
@@ -106,8 +110,7 @@ export default class Browserbase {
     this.baseConnectURL = options.baseConnectURL || 'wss://connect.browserbase.com'
   }
 
-  // `await chromium.connectOverCDP(browserbase.connectUrl())
-  public connectUrl({ sessionId, proxy= false }: { sessionId?: string, proxy?: boolean } = {}) : string {
+  public connectUrl({ sessionId, proxy= false }: ConnectOptions = {}) : string {
     return `${this.baseConnectURL}?apiKey=${this.apiKey}${sessionId ? `&sessionId=${sessionId}` : ''}${proxy ? `&enableProxy=true` : ''}`
   }
 
@@ -261,7 +264,7 @@ export default class Browserbase {
     }
 
     const browser = await chromium.connectOverCDP(
-      `wss://api.browserbase.com?apiKey=${this.apiKey}`
+      this.connectUrl({ sessionId: options.sessionId, proxy: options.proxy })
     )
     const defaultContext = browser.contexts()[0]
     const page = defaultContext.pages()[0]
@@ -292,7 +295,7 @@ export default class Browserbase {
     }
 
     const browser = await chromium.connectOverCDP(
-      `wss://api.browserbase.com?apiKey=${this.apiKey}`
+      this.connectUrl({ sessionId: options.sessionId, proxy: options.proxy })
     )
     const defaultContext = browser.contexts()[0]
     const page = defaultContext.pages()[0]

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export type ClientOptions = {
   apiKey?: string
   projectId?: string
   baseURL?: string
+  baseConnectURL?: string
 }
 
 export type LoadOptions = {
@@ -95,16 +96,23 @@ export type DebugConnectionURLs = {
 export default class Browserbase {
   private apiKey: string
   private projectId: string
-  private baseURL: string
+  private baseApiURL: string
+  private baseConnectURL: string
 
   constructor(options: ClientOptions = {}) {
     this.apiKey = options.apiKey || process.env.BROWSERBASE_API_KEY!
     this.projectId = options.projectId || process.env.BROWSERBASE_PROJECT_ID!
-    this.baseURL = options.baseURL || 'https://www.browserbase.com'
+    this.baseApiURL = options.baseURL || 'https://www.browserbase.com'
+    this.baseConnectURL = options.baseConnectURL || 'wss://connect.browserbase.com'
+  }
+
+  // `await chromium.connectOverCDP(browserbase.connectUrl())
+  public connectUrl({ sessionId, proxy= false }: { sessionId?: string, proxy?: boolean } = {}) : string {
+    return `${this.baseConnectURL}?apiKey=${this.apiKey}${sessionId ? `&sessionId=${sessionId}` : ''}${proxy ? `&enableProxy=true` : ''}`
   }
 
   async listSessions(): Promise<Session[]> {
-    const response = await fetch(`${this.baseURL}/v1/sessions`, {
+    const response = await fetch(`${this.baseApiURL}/v1/sessions`, {
       headers: {
         'x-bb-api-key': this.apiKey,
         'Content-Type': 'application/json',
@@ -115,7 +123,7 @@ export default class Browserbase {
   }
 
   async createSession(options?: CreateSessionOptions): Promise<Session> {
-    const response = await fetch(`${this.baseURL}/v1/sessions`, {
+    const response = await fetch(`${this.baseApiURL}/v1/sessions`, {
       method: 'POST',
       headers: {
         'x-bb-api-key': this.apiKey,
@@ -128,7 +136,7 @@ export default class Browserbase {
   }
 
   async getSession(sessionId: string): Promise<Session> {
-    const response = await fetch(`${this.baseURL}/v1/sessions/${sessionId}`, {
+    const response = await fetch(`${this.baseApiURL}/v1/sessions/${sessionId}`, {
       headers: {
         'x-bb-api-key': this.apiKey,
         'Content-Type': 'application/json',
@@ -142,7 +150,7 @@ export default class Browserbase {
     sessionId: string,
     options: UpdateSessionOptions
   ): Promise<Session> {
-    const response = await fetch(`${this.baseURL}/v1/sessions/${sessionId}`, {
+    const response = await fetch(`${this.baseApiURL}/v1/sessions/${sessionId}`, {
       method: 'POST',
       headers: {
         'x-bb-api-key': this.apiKey,
@@ -156,7 +164,7 @@ export default class Browserbase {
 
   async getSessionRecording(sessionId: string): Promise<SessionRecording[]> {
     const response = await fetch(
-      `${this.baseURL}/v1/sessions/${sessionId}/recording`,
+      `${this.baseApiURL}/v1/sessions/${sessionId}/recording`,
       {
         headers: {
           'x-bb-api-key': this.apiKey,
@@ -170,7 +178,7 @@ export default class Browserbase {
 
   async getSessionLogs(sessionId: string): Promise<SessionLog[]> {
     const response = await fetch(
-      `${this.baseURL}/v1/sessions/${sessionId}/logs`,
+      `${this.baseApiURL}/v1/sessions/${sessionId}/logs`,
       {
         headers: {
           'x-bb-api-key': this.apiKey,
@@ -191,7 +199,7 @@ export default class Browserbase {
     return new Promise<void>((resolve, reject) => {
       const fetchDownload = async () => {
         const response = await fetch(
-          `${this.baseURL}/v1/sessions/${sessionId}/downloads`,
+          `${this.baseApiURL}/v1/sessions/${sessionId}/downloads`,
           {
             method: 'GET',
             headers: {
@@ -223,7 +231,7 @@ export default class Browserbase {
     sessionId: string
   ): Promise<DebugConnectionURLs> {
     const response = await fetch(
-      `${this.baseURL}/v1/sessions/${sessionId}/debug`,
+      `${this.baseApiURL}/v1/sessions/${sessionId}/debug`,
       {
         method: 'GET',
         headers: {


### PR DESCRIPTION
Enable a shorter pattern as follows:
```ts
import { Browserbase } from '@browserbasehq/sdk'
import { chromium } from "playwright-core";

(async () => {
  const browserbase = new Browserbase()
  const session = await browserbase.createSession({ fingerprint: { devices: ['mobile'] } })

  const browser = await chromium.connectOverCDP(
    browserbase.connectUrl({ sessionId: session.id, proxy: true })
  );

  //Getting the default context to ensure the sessions are recorded.
  const defaultContext = browser.contexts()[0];
  const page = defaultContext.pages()[0];

  await page.goto("https://browserbase.com/");
  await page.close();
  await browser.close();
})().catch((error) => console.error(error.message));
```