### PR TITLE
feat: complete session

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @browserbase/eng

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserbasehq/sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserbasehq/sdk",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "puppeteer-core": "^22.10.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,9 @@ export type CreateSessionOptions = {
       height?: number
     }
   }
+  keepAlive?: boolean
+  // duration in seconds. Minimum 60 (1 minute), maximum 21600 (6 hours)
+  timeout?: number
 }
 
 export type Session = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,18 +56,11 @@ export type Session = {
   createdAt: string
   startedAt: string
   endedAt?: string
+  expiresAt: string
   projectId: string
-  status?:
-    | 'NEW'
-    | 'CREATED'
-    | 'ERROR'
-    | 'RUNNING'
-    | 'REQUEST_RELEASE'
-    | 'RELEASING'
-    | 'COMPLETED'
+  status: 'RUNNING' | 'COMPLETED' | 'ERROR' | 'TIMED_OUT'
   taskId?: string
   proxyBytes?: number
-  expiresAt?: string
   avg_cpu_usage?: number
   memory_usage?: number
   details?: string
@@ -152,6 +145,34 @@ export default class Browserbase {
       },
       body: JSON.stringify(mergedOptions),
     })
+
+    return await response.json()
+  }
+
+  async completeSession(sessionId: string): Promise<Session> {
+    if (!sessionId || sessionId === '') {
+      throw new Error('sessionId is required')
+    }
+    if (!this.projectId) {
+      throw new Error(
+        'a projectId is missing: use the options.projectId or BROWSERBASE_PROJECT_ID environment variable to set one.'
+      )
+    }
+
+    const response = await fetch(
+      `${this.baseAPIURL}/v1/sessions/${sessionId}`,
+      {
+        method: 'POST',
+        headers: {
+          'x-bb-api-key': this.apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          projectId: this.projectId,
+          status: 'REQUEST_RELEASE',
+        }),
+      }
+    )
 
     return await response.json()
   }


### PR DESCRIPTION
When a Session is created with `keepAlive` and you want to complete it before its timeout, you should update it with a status of `REQUEST_RELEASE`. To make this simpler through the SDK, there will be a `completeSession` method that takes a `sessionId`.