### PR TITLE
Added createContext method and ability to pass context id & persist boolean to session create options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -390,7 +390,7 @@ export default class Browserbase {
     }
   
     const data = await response.json();
-    return { id: data.id };
+    return data;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,10 @@ export type CreateSessionOptions = {
       width?: number
       height?: number
     }
+    context?: {
+      id: string;
+      persist: boolean;
+    };
   }
   keepAlive?: boolean
   // duration in seconds. Minimum 60 (1 minute), maximum 21600 (6 hours)
@@ -369,6 +373,24 @@ export default class Browserbase {
     const screenshot = await page.screenshot({ fullPage: options.fullPage })
     await browser.close()
     return screenshot
+  }
+
+  async createContext(): Promise<{ id: string }> {
+    const response = await fetch(`${this.baseAPIURL}/v1/contexts`, {
+      method: 'POST',
+      headers: {
+        'x-bb-api-key': this.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ projectId: this.projectId }),
+    });
+  
+    if (!response.ok) {
+      throw new Error('Failed to create context');
+    }
+  
+    const data = await response.json();
+    return { id: data.id };
   }
 }
 

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from 'node:test'
 import { expect } from 'chai'
-import { Browserbase, BrowserbaseAISDK } from '../src'
+import { Browserbase, BrowserbaseAISDK, CreateSessionOptions } from '../src'
 
 describe('Browserbase', () => {
   let browserbase: Browserbase
@@ -72,5 +72,22 @@ describe('Browserbase', () => {
     const ai = BrowserbaseAISDK(browserbase, { textContent: true })
     const { page } = await ai.execute({ url: 'https://example.com' })
     expect(page).contain('Example Domain')
+  })
+
+  it('should create a session with dynamically created context', async () => {
+    const createContextResponse = await browserbase.createContext();
+    const contextId = createContextResponse.id;
+  
+    // Use the created context ID in session creation
+    const sessionOptions: CreateSessionOptions = {
+      browserSettings: {
+        context: {
+          id: contextId,
+          persist: true
+        }
+      }
+    };
+    const { id } = await browserbase.createSession(sessionOptions);
+    const session = await browserbase.getSession(id);
   })
 })


### PR DESCRIPTION
As per my conversation with Paul. Not sure if you'll want this createContext method or not but figured i'd add it anyways - the ability to add a context to the session is what i'm after.